### PR TITLE
Weight factored jumps and climbing

### DIFF
--- a/objects/obj_block/Create_0.gml
+++ b/objects/obj_block/Create_0.gml
@@ -10,7 +10,7 @@ hpMax= 4;
 hp = hpNormal;
 
 //set mass
-mass = 16
+mass = 12
 
 //Set friction
 fric = 2.4

--- a/objects/obj_character/Alarm_1.gml
+++ b/objects/obj_character/Alarm_1.gml
@@ -1,0 +1,3 @@
+/// @description Block climbing pause
+
+active = true

--- a/objects/obj_character/Create_0.gml
+++ b/objects/obj_character/Create_0.gml
@@ -4,7 +4,7 @@ event_inherited();
 //physics
 active = true;
 frozen = false;
-mass = 8;
+mass = 24;
 hpNormal = 100;
 
 //team - team object
@@ -30,7 +30,7 @@ if (global.cooperativeMode) {
     }
 else {
     jumpsMax = 2;
-    jumpHeight = 6;
+    jumpHeight = 8.5;
     }
 
 //gravity

--- a/objects/obj_character/Step_0.gml
+++ b/objects/obj_character/Step_0.gml
@@ -168,12 +168,18 @@ if (active) {
 
     // Jump
     if (jumps > 0) {
-		if not has_jetpack{
+		//if not has_jetpack{
 	        if (jumpPressed) {
-	            vspeed = -jumpHeight;
+				if instance_exists(grabObject){
+					var total_mass = mass + grabObject.mass
+				}
+			
+				else var total_mass = mass
+
+	            vspeed = -(jumpHeight - total_mass / 12);
 	            jumps -= 1;
 	        }
-		}
+		//}
     }
 
     //push blocks
@@ -258,7 +264,7 @@ if (active) {
             //if (playerInput == -1) InputPlayer.inputs[RIGHTSELC_KEY] = scr_toggleKey(InputPlayer.inputs[RIGHTSELC_KEY]); //unpress key
         }
 	
-	//Jetpack starting boost
+	/*//Jetpack starting boost
 	if firePressed{
 		if has_jetpack{
 			if grabObject.working{
@@ -269,7 +275,7 @@ if (active) {
 			}
 		}
 	}
-	
+	*/
 	//Jetpack flying
 	if fireIsPressed{
 		if has_jetpack{

--- a/objects/obj_character/Step_0.gml
+++ b/objects/obj_character/Step_0.gml
@@ -182,13 +182,45 @@ if (active) {
 		//}
     }
 
-    //push blocks
-    with(instance_place(x+sign(hspeed)*2,y,par_physics))
-        {
+    //block collisions
+    with(instance_place(x+sign(hspeed)*2,y,par_physics)){
+		//Push blocks
         if (id != other.grabObject && not frozen && !stuck) {
             x+=scr_contactx(other.hspeed);
             }
+		
+		//Climb blocks
+		if (id != other.grabObject) and frozen{
+			//Slide slowly down blocks' sides
+			other.hspeed = 0
+			other.vspeed = 0
+			
+			//Climb up them
+			if other.jumpPressed{
+				//While climbing
+				if other.y + other.sprite_height - 6 > y{
+					if other.energy >= .5{
+						other.vspeed = -5 
+						other.energy -= .5
+					}
+				}
+				
+				//Once at the top
+				else{
+					if other.energy >= 1{
+						other.x = x - other.dir * 3/4 * sprite_width
+						other.y = y - 16
+						with other alarm_set(1,15)
+						other.vspeed = 0
+						other.hspeed = 0
+						other.active = false
+						other.energy -= 1
+						exit
+					}
+				}
+			}
         }
+	}
 
     // Apply gravity (and jumping)
     if (vspeed < gravityMax) {
@@ -264,18 +296,6 @@ if (active) {
             //if (playerInput == -1) InputPlayer.inputs[RIGHTSELC_KEY] = scr_toggleKey(InputPlayer.inputs[RIGHTSELC_KEY]); //unpress key
         }
 	
-	/*//Jetpack starting boost
-	if firePressed{
-		if has_jetpack{
-			if grabObject.working{
-				if not place_free(x, y + vspeed + 2){
-					vspeed -= 2*jumpHeight/3
-					grabObject.image_index = 1
-				}
-			}
-		}
-	}
-	*/
 	//Jetpack flying
 	if fireIsPressed{
 		if has_jetpack{
@@ -474,82 +494,86 @@ if (active) {
 
 /// hp and energy
 if (active) {
-//Hurt the player if they fall below the water
-if(y > room_height-obj_wall.sprite_height-obj_control.water_height)
-{hp -= .4;
-}
+	//Hurt the player if they fall below the water
+	if(y > room_height-obj_wall.sprite_height-obj_control.water_height){
+		hp -= .4;
+	}
 
-//Collision with patrols
+	//Collision with patrols
     with (instance_place(x, y, par_enemy)) {
         other.hp -= dmg;
         }
 
-//Collision with pirahnas
-if(place_meeting(x,y,obj_pirahna))
-{hp -= 1;
-}
-
-//Collision with blown up big blocks
-with (instance_place(x, y, obj_blockBig)){
-	if hp <= 0 {
-		other.hp -= 10
+	//Collision with pirahnas
+	if(place_meeting(x,y,obj_pirahna)){
+		hp -= 1;
 	}
-}
 
-//Jump on trampolines
-var min_jump_speed = 3
-if place_meeting(x, y + vspeed/4, obj_trampoline){
-	if vspeed > min_jump_speed{
-		vspeed *= -1
+	//Collision with blown up big blocks
+	with (instance_place(x, y, obj_blockBig)){
+		if hp <= 0 {
+			other.hp -= 10
+		}
 	}
-}
 
-//Kill the player if they run out of health
-if(hp < 1) {
-    //create corpse
-    with (instance_create(x,y,obj_corpse)) sprite_index = other.sprite_index;
-    //create pirahna
-    with (instance_create(x,y,obj_pirahna)) {
-        playerInput = other.playerInput;
-        InputPlayer = other.InputPlayer;
-        inputType = other.inputType;
-        if (instance_exists(InputPlayer)) InputPlayer.gameCharacter = self;
-        }
-    //drop object if grabbed
-    if (instance_exists(grabObject)) {
-        //remove grabObject's holder
-        grabObject.holder = noone;
-        grabObject.active = true;
-        }
-    //subtract score
-    //team.tScore += (room_height-yMin)*global.scoreY;
-    //subtract life
-    team.tLives -= 1;
-    //keep in bounds
-    if (team.tLives < 0) team.tLives = 0;
-    //destroy self
-    instance_destroy(self);
-    }
+	//Jump on trampolines
+	var min_jump_speed = 3
+	if place_meeting(x, y + vspeed/4, obj_trampoline){
+		if vspeed > min_jump_speed{
+			vspeed *= -1
+		}
+	}
 
-    //recharge station
-    if (place_meeting(x, y, obj_rechargeStation)) {
-        if (energy < energy_max) {
-            energy +=1;
-            }
-        }
+	//Kill the player if they run out of health
+	if(hp < 1) {
+	    //create corpse
+	    with (instance_create(x,y,obj_corpse)) sprite_index = other.sprite_index;
+		
+	    //create pirahna
+	    with (instance_create(x,y,obj_pirahna)) {
+	        playerInput = other.playerInput;
+	        InputPlayer = other.InputPlayer;
+	        inputType = other.inputType;
+	        if (instance_exists(InputPlayer)) InputPlayer.gameCharacter = self;
+	        }
+			
+	    //drop object if grabbed
+	    if (instance_exists(grabObject)) {
+	        //remove grabObject's holder
+	        grabObject.holder = noone;
+	        grabObject.active = true;
+	        }
+			
+	    //subtract score
+	    //team.tScore += (room_height-yMin)*global.scoreY;
+	    //subtract life
+	    team.tLives -= 1;
+		
+	    //keep in bounds
+	    if (team.tLives < 0) team.tLives = 0;
+	    //destroy self
+	    instance_destroy(self);
+	}
+
+	//recharge station
+	if (place_meeting(x, y, obj_rechargeStation)) {
+	    if (energy < energy_max) {
+	        energy +=1;
+	        }
+	    }
     
-    //hp
-    with(instance_place(x, y, obj_health)) {
-        //add health
-        other.hp += value;
-        //add lives
-        other.team.tLives += 1;
-        //keep in bounds
-        if (other.hp > other.hp_max) other.hp = other.hp_max;
-        //destroy
-        instance_destroy();
-        }
-    }
+	//hp
+	with(instance_place(x, y, obj_health)) {
+	    //add health
+	    other.hp += value;
+	    //add lives
+	    other.team.tLives += 1;
+	    //keep in bounds
+	    if (other.hp > other.hp_max) other.hp = other.hp_max;
+	    //destroy
+	    instance_destroy();
+	}
+}
 
 ///win
 if (place_meeting(x, y, obj_door)) {

--- a/objects/obj_character/obj_character.yy
+++ b/objects/obj_character/obj_character.yy
@@ -43,6 +43,16 @@
             "enumb": 0,
             "eventtype": 8,
             "m_owner": "21b88cb8-77c4-4c41-a084-1615b64f7d59"
+        },
+        {
+            "id": "fe34766d-c394-4dc9-ab38-82e0d0f0012b",
+            "modelName": "GMEvent",
+            "mvc": "1.0",
+            "IsDnD": false,
+            "collisionObjectId": "00000000-0000-0000-0000-000000000000",
+            "enumb": 1,
+            "eventtype": 2,
+            "m_owner": "21b88cb8-77c4-4c41-a084-1615b64f7d59"
         }
     ],
     "maskSpriteId": "00000000-0000-0000-0000-000000000000",

--- a/objects/obj_jetpack/Create_0.gml
+++ b/objects/obj_jetpack/Create_0.gml
@@ -5,7 +5,7 @@ event_inherited();
 
 image_speed = 0
 mass = 25
-jetpack_cost = 1
+jetpack_cost = 1.2
 fric = 4.4
 working = true
 


### PR DESCRIPTION
## Number of Issue Fixed
#47 #49 

### Changes Proposed in the Pull Request:
__Mass factored jumps__
- players now jump 8.5 - their total mass/10 (Total mass = their mass + carrying item mass)
- player mass is now 20
- block mass is now 12

__Climbing__
- When a player runs into the side of a _frozen_ block their player stops, and slowly slips down the block
- The player can then press the jump button to _struggle_ up the block (.5 energy/struggle)
- When the player is near the top, pressing jump will _climb_ the block (1 energy/climb)
- Once on top the player will be frozen for 15 steps to give the player time to release keys if they wish to stand still on the top of the block

#### Notes for Reviewer
- I notice on rare occasion a block might be thrown extremely far, much further than the mass should allow. Keep an eye out for a glitch that might 
